### PR TITLE
Fix: Mobile layout allows unintended horizontal scrolling on post view

### DIFF
--- a/src/components/Article/Body/index.jsx
+++ b/src/components/Article/Body/index.jsx
@@ -54,7 +54,7 @@ const Wrapper = styled.div`
     padding: 0.2em 0.5em;
     border-radius: 4px;
     font-size: 0.75em;
-    white-space: nowrap; /* Prevent text wrapping */
+    
     opacity: 0;
     transition:
       opacity 0.3s ease-in-out,


### PR DESCRIPTION
Closes #3

This PR fixes the horizontal scrolling issue on mobile post views by removing `white-space: nowrap;` from the `.copied-message` class in `src/components/Article/Body/index.jsx`. This allows the "Copied!" message to wrap, preventing it from overflowing the screen.