### PR TITLE
feat: Add read time display to PostList

### DIFF
--- a/src/components/Article/Body/index.jsx
+++ b/src/components/Article/Body/index.jsx
@@ -54,7 +54,7 @@ const Wrapper = styled.div`
     padding: 0.2em 0.5em;
     border-radius: 4px;
     font-size: 0.75em;
-    white-space: nowrap; /* Prevent text wrapping */
+    
     opacity: 0;
     transition:
       opacity 0.3s ease-in-out,

--- a/src/components/PostList/index.jsx
+++ b/src/components/PostList/index.jsx
@@ -96,6 +96,7 @@ const PostList = ({ postList }) => {
                   ` | ${Array.isArray(post.frontmatter.category)
                     ? post.frontmatter.category.join(", ")
                     : post.frontmatter.category}`}
+                {post.fields.readingTime && ` | Læsetid: ${Math.round(post.fields.readingTime.minutes)} min.`}
               </Date>
               {frontpageImage && gatsbyImage && (
                 <Link to={slug}>

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -70,6 +70,9 @@ export const pageQuery = graphql`
         excerpt(pruneLength: 200, truncate: true)
         fields {
           slug
+          readingTime {
+            minutes
+          }
         }
         frontmatter {
           date(formatString: "DD. MMMM, YYYY", locale: "da")


### PR DESCRIPTION
Closes #8

This PR adds the estimated read time to the post list display on the front page, next to the post date and category. This reuses the existing read time calculation logic.