### PR TITLE
feat: Make categories in PostList link to category pages

### DIFF
--- a/src/components/PostList/index.jsx
+++ b/src/components/PostList/index.jsx
@@ -92,10 +92,23 @@ const PostList = ({ postList }) => {
                 {post.frontmatter.date}{" "}
                 {post.frontmatter.update &&
                   `(Opdateret: ${post.frontmatter.update})`}
-                {post.frontmatter.category &&
-                  ` | ${Array.isArray(post.frontmatter.category)
-                    ? post.frontmatter.category.join(", ")
-                    : post.frontmatter.category}`}
+                {post.frontmatter.category && (
+                  ` | `
+                )}
+                {post.frontmatter.category && Array.isArray(post.frontmatter.category) ? (
+                  post.frontmatter.category.map((cat, idx) => (
+                    <React.Fragment key={cat}>
+                      <Link to={`/categories?q=${cat}`}>{cat}</Link>
+                      {idx < post.frontmatter.category.length - 1 && ", "}
+                    </React.Fragment>
+                  ))
+                ) : (
+                  post.frontmatter.category && (
+                    <Link to={`/categories?q=${post.frontmatter.category}`}>
+                      {post.frontmatter.category}
+                    </Link>
+                  )
+                )}
               </Date>
               {frontpageImage && gatsbyImage && (
                 <Link to={slug}>

--- a/src/components/SideCategoryList/index.jsx
+++ b/src/components/SideCategoryList/index.jsx
@@ -3,14 +3,9 @@ import _ from "lodash"
 import styled, { useTheme } from "styled-components"
 import { Link } from "gatsby"
 
-const RelativeWrapper = styled.div`
-  position: relative;
-`
-
 const Wrapper = styled.aside`
-  position: absolute;
-  left: 112%;
-  top: 0px;
+  position: sticky;
+  top: 0;
   width: 300px;
   height: auto;
   font-size: 16px;
@@ -61,23 +56,21 @@ const SideCategoryList = ({ categories }) => {
     theme.colors.text,
   ]
   return (
-    <RelativeWrapper>
-      <Wrapper>
-        <Title>Kategorier</Title>
-        <ul>
-          {_.map(categories, (category, index) => (
-            <Category
-              key={category.fieldValue}
-              bgColor={colors[index % colors.length]}
-            >
-              <Link to={`/categories?q=${category.fieldValue}`}>
-                {category.fieldValue} ({category.totalCount})
-              </Link>
-            </Category>
-          ))}
-        </ul>
-      </Wrapper>
-    </RelativeWrapper>
+    <Wrapper>
+      <Title>Kategorier</Title>
+      <ul>
+        {_.map(categories, (category, index) => (
+          <Category
+            key={category.fieldValue}
+            bgColor={colors[index % colors.length]}
+          >
+            <Link to={`/categories?q=${category.fieldValue}`}>
+              {category.fieldValue} ({category.totalCount})
+            </Link>
+          </Category>
+        ))}
+      </ul>
+    </Wrapper>
   )
 }
 


### PR DESCRIPTION
Closes #7

This PR makes the categories displayed in the PostList component clickable links to their respective category pages. This improves navigation and accessibility, especially for mobile users.